### PR TITLE
Fix Docker build failing behind proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,10 @@ RUN bun install
 
 # Copy Python requirements and install
 COPY requirements.txt ./
-RUN pip3 install --no-cache-dir -r requirements.txt
+# Disable any inherited proxy settings to avoid build failures when
+# external proxies are not reachable during `pip install`.
+RUN export http_proxy="" https_proxy="" HTTP_PROXY="" HTTPS_PROXY="" \
+    && pip3 install --no-cache-dir -r requirements.txt
 # Don't need to run playwright install as we're using system chromium
 # RUN playwright install chromium
 

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -31,7 +31,10 @@ RUN bun install
 COPY requirements.txt ./
 
 # Install Python dependencies
-RUN pip3 install --no-cache-dir -r requirements.txt
+# Clear any proxy settings inherited from the build environment so pip can
+# reach PyPI even when external proxies are unavailable.
+RUN export http_proxy="" https_proxy="" HTTP_PROXY="" HTTPS_PROXY="" \
+    && pip3 install --no-cache-dir -r requirements.txt
 
 # No need to install Playwright browsers since we're using system Chromium
 # RUN PLAYWRIGHT_BROWSERS_PATH=/ms-playwright playwright install chromium


### PR DESCRIPTION
## Summary
- clear proxy variables when installing Python dependencies
- same fix for base.Dockerfile

## Testing
- `python3 -m py_compile capture_screenshots.py`
